### PR TITLE
Add local development helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ git clone https://github.com/JVCarmichael0959/pathfinder.git
 cd pathfinder
 # copy .env template and fill in ACLED credentials
 cp .env.example .env
-docker compose up      # PostGIS + pgRouting + Jupyter + Flask
+# start the stack (PostGIS + pgRouting + Jupyter)
+docker compose up
+
+# or run the helper script
+bash scripts/setup_dev_env.sh
 
 ## Data ingest (raw ➜ PostGIS)
 

--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# setup_dev_env.sh - Initialize local development environment
+#
+# 1. Ensure .env exists
+# 2. Install Python dependencies
+# 3. Start docker compose services
+set -euo pipefail
+
+# Step 1: environment file
+if [ ! -f .env ]; then
+    cp .env.example .env
+    echo "Created .env from template. Please edit ACLED_TOKEN and ACLED_EMAIL." >&2
+fi
+
+# Step 2: Python deps (optional if using containers only)
+if command -v pip >/dev/null 2>&1; then
+    pip install -r requirements.txt
+fi
+
+# Step 3: start Docker services
+echo "Starting docker containers..."
+docker compose up -d
+
+echo "\n✅  Development environment is starting." \
+     "Access Jupyter at http://localhost:8888 when ready." >&2


### PR DESCRIPTION
## Summary
- add `scripts/setup_dev_env.sh` helper for setting up local dev environment
- document the new helper script in the README

## Testing
- `python -m compileall -q pathfinder scripts`