### PR TITLE
Add basic Streamlit dashboard

### DIFF
--- a/.github/workflows/deploy_dashboard.yml
+++ b/.github/workflows/deploy_dashboard.yml
@@ -1,0 +1,40 @@
+name: Deploy dashboard
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: streamlit run dashboard/app.py --server.headless true &
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST: db
+          POSTGRES_DB: pathfinder
+      - run: |
+          sleep 15
+          mkdir site
+          wget -O site/index.html http://localhost:8501
+        timeout-minutes: 2
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/configure-pages@v3
+      - uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ bash scripts/setup_dev_env.sh
 | `sql/03_geo_join.sql` | Materialised view of events within 5 km of primary roads | `psql -f sql/03_geo_join.sql` |
 | `sql/04_last12months_view.sql` | Materialised view of the last 12 months metrics | `psql -f sql/04_last12months_view.sql` |
 
+## Dashboard
+
+Run a small Streamlit app showing the last 12 months of ACLED data:
+
+```bash
+streamlit run dashboard/app.py
+```
+
+
 These scripts write raw files to **`data/raw/`** and populate the corresponding PostGIS tables inside the `db` container (`events_raw`, `sa_monthly_violence`, `sudan_roads_osm`).
 
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,53 @@
+import streamlit as st
+import pandas as pd
+from pathfinder.db import get_engine
+
+st.set_page_config(page_title="ACLED Last 12 Months", layout="wide")
+
+@st.cache_data
+def load_data():
+    sql = """
+    SELECT month_start, admin1, admin2, events, fatalities
+    FROM acled_monthly_clean
+    WHERE month_start >= (date_trunc('month', CURRENT_DATE) - INTERVAL '11 months')
+    """
+    return pd.read_sql(sql, get_engine(), parse_dates=['month_start'])
+
+df = load_data()
+if df.empty:
+    st.error("No data returned from database")
+    st.stop()
+
+# Monthly totals line chart
+monthly = df.groupby('month_start')[['events','fatalities']].sum().reset_index()
+st.header("Monthly totals")
+st.line_chart(monthly.set_index('month_start'))
+
+# Heatmap of events by admin2 per month
+st.header("Events heatmap by admin2")
+heat = (
+    df.groupby(['admin2','month_start'])['events']
+      .sum()
+      .unstack(fill_value=0)
+)
+heat_data = heat.reset_index().melt('admin2', var_name='month', value_name='events')
+import altair as alt
+chart = alt.Chart(heat_data).mark_rect().encode(
+    x='month:T',
+    y=alt.Y('admin2:N', sort='-x'),
+    color=alt.Color('events:Q', scale=alt.Scale(scheme='reds')),
+    tooltip=['admin2','month','events']
+).properties(height=400)
+st.altair_chart(chart, use_container_width=True)
+
+# Top N risky admin2
+N = st.slider('Top N admin2 areas by events', 5, 20, 10)
+top_admin2 = (
+    df.groupby('admin2')['events']
+      .sum()
+      .sort_values(ascending=False)
+      .head(N)
+      .reset_index()
+)
+st.header("Top risky admin2")
+st.dataframe(top_admin2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,6 @@ matplotlib
 
 # ── misc ───────────────────────────────────────────────
 python-dotenv
+# --- dashboard ---
+streamlit
+altair


### PR DESCRIPTION
## Summary
- add Streamlit and altair dependencies
- implement `dashboard/app.py` for last‑12‑months charts
- document dashboard usage in README
- add workflow to publish dashboard with GitHub Pages

## Testing
- `python -m py_compile dashboard/app.py`
- `pytest -q` *(fails: command not found)*