### PR TITLE
Refactor ETL scripts with logging and error handling

### DIFF
--- a/pathfinder/__init__.py
+++ b/pathfinder/__init__.py
@@ -7,6 +7,17 @@ __all__ = [
 ]
 __version__ = "0.1.0"
 
-from .db import get_engine
-from .risk_tsp import plan_route
-from .bayesian import admin_event_rates, road_segment_risk, update_risk_table
+try:  # optional dependencies may be missing during tests
+    from .db import get_engine
+except Exception:  # pragma: no cover
+    get_engine = None
+
+try:
+    from .risk_tsp import plan_route
+except Exception:  # pragma: no cover
+    plan_route = None
+
+try:
+    from .bayesian import admin_event_rates, road_segment_risk, update_risk_table
+except Exception:  # pragma: no cover
+    admin_event_rates = road_segment_risk = update_risk_table = None

--- a/pathfinder/etl/enrich_admin2.py
+++ b/pathfinder/etl/enrich_admin2.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Load admin boundaries and enrich monthly ACLED data."""
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+import sqlalchemy as sa
+from sqlalchemy.exc import SQLAlchemyError
+
+from ..utils.logging import setup_logging
+
+logger = setup_logging(__name__)
+
+DEFAULT_DB_URL = os.getenv(
+    "DATABASE_URL", "postgresql://postgres:postgres@db:5432/pathfinder"
+)
+
+
+def ensure_postgis(engine: sa.Engine) -> None:
+    """Ensure the PostGIS extension exists."""
+    with engine.begin() as conn:
+        conn.exec_driver_sql("CREATE EXTENSION IF NOT EXISTS postgis;")
+
+
+def load_admin2(shp: Path, db_url: str = DEFAULT_DB_URL) -> None:
+    """Load the admin2 shapefile into PostGIS via ogr2ogr."""
+    if not shp.exists():
+        raise FileNotFoundError(shp)
+    url = sa.engine.URL.create(db_url)
+    ogr_cmd = [
+        "ogr2ogr",
+        "-f",
+        "PostgreSQL",
+        f"PG:dbname={url.database} host={url.host} user={url.username} password={url.password}",
+        str(shp),
+        "-nln",
+        "geo_admin2",
+        "-nlt",
+        "MULTIPOLYGON",
+        "-overwrite",
+    ]
+    try:
+        subprocess.run(ogr_cmd, check=True)
+        logger.info("Loaded %s into geo_admin2", shp)
+    except subprocess.CalledProcessError as exc:
+        logger.error("ogr2ogr failed: %s", exc)
+        raise
+
+
+def enrich_monthly(engine: sa.Engine) -> None:
+    """Add admin names to monthly ACLED table."""
+    sql = """
+    ALTER TABLE IF EXISTS acled_monthly_clean
+        ADD COLUMN IF NOT EXISTS geom geometry(Point,4326);
+
+    UPDATE acled_monthly_clean
+    SET geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
+    WHERE geom IS NULL;
+
+    DROP TABLE IF EXISTS acled_monthly_enriched;
+    CREATE TABLE acled_monthly_enriched AS
+    SELECT a.*, g.admin2_name, g.admin1_name
+    FROM acled_monthly_clean a
+    LEFT JOIN geo_admin2 g
+      ON ST_Contains(g.geom, a.geom);
+
+    CREATE INDEX IF NOT EXISTS acled_monthly_enriched_geom_idx
+      ON acled_monthly_enriched USING GIST(geom);
+    """
+    try:
+        with engine.begin() as conn:
+            conn.exec_driver_sql(sql)
+        logger.info("acled_monthly_enriched created")
+    except SQLAlchemyError as exc:
+        logger.error("Failed to run enrichment SQL: %s", exc)
+        raise
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    """CLI entry point."""
+    shp = Path("data/geo/sudan_admin2.shp")
+    engine = sa.create_engine(DEFAULT_DB_URL)
+    try:
+        ensure_postgis(engine)
+        load_admin2(shp, DEFAULT_DB_URL)
+        enrich_monthly(engine)
+    except Exception as exc:
+        logger.error("Script failed: %s", exc)
+        raise
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+
+# DEBUG QUESTIONS:
+# 1. Does the PostGIS table geo_admin2 already exist before loading?
+# 2. What happens if ogr2ogr cannot access the shapefile path?
+# 3. How might this fail when run in a CI pipeline?

--- a/pathfinder/etl/pull_acled.py
+++ b/pathfinder/etl/pull_acled.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Pull ACLED events for one or more countries or regions.
+
+This module fetches recent ACLED conflict events, saves a CSV backup and
+writes the results to PostGIS. It can be used as a library or run from the
+command line.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+import pandas as pd
+import requests
+from requests.exceptions import RequestException
+from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
+
+from ..utils.logging import setup_logging
+
+# ---------------------------------------------------------------------------
+# logging
+# ---------------------------------------------------------------------------
+logger = setup_logging(__name__)
+
+# ---------------------------------------------------------------------------
+# constants
+# ---------------------------------------------------------------------------
+ISO_CACHE = Path("data/meta/iso_cache.csv")
+DEFAULT_DB_URL = "postgresql://postgres:postgres@db:5432/pathfinder"
+DAYS_BACK = 14
+
+# region aliases (add more if desired)
+REGION_ALIASES: Dict[str, int] = {
+    "western_africa": 1,
+    "middle_africa": 2,
+    "eastern_africa": 3,
+    "southern_africa": 4,
+    "northern_africa": 5,
+    "south_asia": 7,
+    "southeast_asia": 9,
+    "middle_east": 11,
+    "europe": 12,
+    "caucasus_central_asia": 13,
+    "central_america": 14,
+    "south_america": 15,
+    "caribbean": 16,
+    "east_asia": 17,
+    "north_america": 18,
+    "oceania": 19,
+    "antarctica": 20,
+}
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def load_iso_table(token: str, email: str) -> pd.DataFrame:
+    """Return a dataframe of ISO codes, caching the result for a day."""
+    try:
+        if ISO_CACHE.exists() and ISO_CACHE.stat().st_mtime > time.time() - 86400:
+            df = pd.read_csv(ISO_CACHE)
+            logger.debug("Loaded ISO cache with %d rows", len(df))
+        else:
+            logger.info("Downloading country list from ACLED …")
+            url = (
+                "https://api.acleddata.com/country/read?"
+                f"key={token}&email={email}&limit=0&format=json"
+            )
+            resp = requests.get(url, timeout=30)
+            resp.raise_for_status()
+            df = pd.DataFrame(resp.json().get("data", []))["country iso iso3".split()]  # TODO: confirm field names
+            ISO_CACHE.parent.mkdir(parents=True, exist_ok=True)
+            df.to_csv(ISO_CACHE, index=False)
+            logger.debug("Saved ISO cache → %s", ISO_CACHE)
+    except (RequestException, ValueError) as exc:
+        logger.error("Failed to fetch ISO table: %s", exc)
+        raise
+    return df
+
+
+def build_queries(items: Iterable[str], lookup: Dict[str, str], aliases: Dict[str, int]) -> Tuple[str, str, List[str]]:
+    """Build ISO and region query strings for the API."""
+    iso_params: List[str] = []
+    region_params: List[str] = []
+    missing: List[str] = []
+    for item in items:
+        if item in lookup:
+            iso_params.append(f"&iso={lookup[item]}")
+        elif item in aliases:
+            region_params.append(f"&region={aliases[item]}")
+        else:
+            missing.append(item)
+    return "".join(iso_params), "".join(region_params), missing
+
+
+def fetch_acled(token: str, email: str, iso_query: str, region_query: str,
+                days_back: int = DAYS_BACK) -> pd.DataFrame:
+    """Fetch ACLED events within ``days_back`` days."""
+    today = dt.date.today()
+    start_date = today - dt.timedelta(days=days_back)
+    url = (
+        "https://api.acleddata.com/acled/read?"
+        f"email={email}&key={token}"
+        f"{iso_query}{region_query}"
+        f"&event_date={start_date}|{today}"  # DEBUG TIP: If this fails, check the ACLED_TOKEN in your .env file
+        "&limit=20000&format=json"
+    )
+    try:
+        logger.info("Fetching ACLED: %s", url)
+        resp = requests.get(url, timeout=60)
+        resp.raise_for_status()
+        js = resp.json()
+        rows = js.get("data", [])
+        if not rows:
+            raise ValueError("Query succeeded but returned zero rows")
+        df = pd.DataFrame(rows)
+        logger.debug("Fetched %d rows", len(df))
+        return df
+    except RequestException as exc:
+        logger.error("ACLED request failed: %s", exc)
+        raise
+    except ValueError as exc:
+        logger.error("ACLED response error: %s", exc)
+        raise
+
+
+def save_csv(df: pd.DataFrame, countries: Iterable[str]) -> Path:
+    """Write dataframe to ``data/raw`` and return the path."""
+    raw_dir = Path("data/raw")
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    out_csv = raw_dir / f"acled_{'_'.join(countries)}_{dt.date.today()}.csv"
+    df.to_csv(out_csv, index=False)
+    logger.info("Saved %d rows → %s", len(df), out_csv)
+    return out_csv
+
+
+def write_postgis(df: pd.DataFrame, table: str = "events_raw",
+                  db_url: str = DEFAULT_DB_URL) -> None:
+    """Write dataframe to a PostGIS table."""
+    try:
+        engine = create_engine(db_url)
+        engine.connect().close()
+    except SQLAlchemyError as exc:
+        logger.error("Database connection failed: %s", exc)
+        raise
+    try:
+        df.to_sql(table, engine, if_exists="replace", index=False)
+        logger.info("Written to PostGIS table %s", table)
+    except SQLAlchemyError as exc:
+        logger.error("Failed writing to PostGIS: %s", exc)
+        raise
+
+
+def list_countries(token: str, email: str) -> List[str]:
+    """Return list of valid country names from ACLED."""
+    df = load_iso_table(token, email)
+    return sorted(df["country"].tolist())
+
+
+# ---------------------------------------------------------------------------
+# main entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: Iterable[str] | None = None) -> None:
+    """Entry point for CLI usage."""
+    args = list(argv) if argv is not None else sys.argv[1:]
+
+    if "--help" in args or "-h" in args:
+        print(__doc__)
+        return
+    list_mode = "--list" in args
+    args = [a for a in args if a != "--list"]
+
+    token = os.getenv("ACLED_TOKEN")
+    email = os.getenv("ACLED_EMAIL")
+    if not token or not email:
+        logger.error("ACLED_TOKEN and ACLED_EMAIL environment variables must be set")
+        sys.exit(1)
+
+    if list_mode:
+        for name in list_countries(token, email):
+            print(name)
+        return
+
+    if not args:
+        logger.error("No country or region arguments supplied. Use --list to see options")
+        sys.exit(1)
+
+    try:
+        iso_df = load_iso_table(token, email)
+        lookup = iso_df.assign(iso=iso_df["iso"].astype(str)).set_index("country")["iso"].to_dict()
+        iso_q, region_q, missing = build_queries(args, lookup, REGION_ALIASES)
+        if missing:
+            logger.error("Unrecognised names: %s", missing)
+            sys.exit(1)
+        df = fetch_acled(token, email, iso_q, region_q)
+        save_csv(df, args)
+        write_postgis(df)
+    except Exception as exc:
+        logger.error("Script failed: %s", exc)
+        sys.exit(1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+
+# DEBUG QUESTIONS:
+# 1. What happens if ACLED returns an empty payload?
+# 2. Does the PostGIS table already exist before this script writes to it?
+# 3. How might this fail when run in a CI pipeline?

--- a/pathfinder/utils/logging.py
+++ b/pathfinder/utils/logging.py
@@ -1,0 +1,30 @@
+import logging
+from typing import Optional
+
+
+def setup_logging(name: str = __name__, log_file: Optional[str] = None,
+                  level: int = logging.INFO) -> logging.Logger:
+    """Set up and return a logger with a standard format.
+
+    Parameters
+    ----------
+    name : str
+        Name of the logger.
+    log_file : Optional[str]
+        Optional file path to also write log records.
+    level : int
+        Logging level, defaults to :data:`logging.INFO`.
+
+    Returns
+    -------
+    logging.Logger
+        Configured logger instance.
+    """
+
+    fmt = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+    handlers = [logging.StreamHandler()]
+    if log_file:
+        handlers.append(logging.FileHandler(log_file))
+
+    logging.basicConfig(level=level, format=fmt, handlers=handlers, force=True)
+    return logging.getLogger(name)

--- a/scripts/enrich_admin2.py
+++ b/scripts/enrich_admin2.py
@@ -1,54 +1,7 @@
 #!/usr/bin/env python3
 """Load admin boundaries and enrich monthly ACLED data."""
-import os
-import subprocess
-from pathlib import Path
-import sqlalchemy as sa
 
-DB_URL = os.getenv(
-    "DATABASE_URL",
-    "postgresql://postgres:postgres@db:5432/pathfinder",
-)
-engine = sa.create_engine(DB_URL)
+from pathfinder.etl.enrich_admin2 import main
 
-# ensure PostGIS extension
-with engine.begin() as conn:
-    conn.exec_driver_sql("CREATE EXTENSION IF NOT EXISTS postgis;")
-
-# path to admin2 shapefile
-shp = Path("data/geo/sudan_admin2.shp")
-if not shp.exists():
-    raise SystemExit(f"Missing {shp}")
-
-# load shapefile via ogr2ogr
-url = sa.engine.URL.create(DB_URL)
-ogr_cmd = [
-    "ogr2ogr", "-f", "PostgreSQL",
-    f"PG:dbname={url.database} host={url.host} user={url.username} password={url.password}",
-    str(shp), "-nln", "geo_admin2", "-nlt", "MULTIPOLYGON", "-overwrite",
-]
-subprocess.run(ogr_cmd, check=True)
-
-SQL = """
-ALTER TABLE IF EXISTS acled_monthly_clean
-    ADD COLUMN IF NOT EXISTS geom geometry(Point,4326);
-
-UPDATE acled_monthly_clean
-SET geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
-WHERE geom IS NULL;
-
-DROP TABLE IF EXISTS acled_monthly_enriched;
-CREATE TABLE acled_monthly_enriched AS
-SELECT a.*, g.admin2_name, g.admin1_name
-FROM acled_monthly_clean a
-LEFT JOIN geo_admin2 g
-  ON ST_Contains(g.geom, a.geom);
-
-CREATE INDEX IF NOT EXISTS acled_monthly_enriched_geom_idx
-  ON acled_monthly_enriched USING GIST(geom);
-"""
-
-with engine.begin() as conn:
-    conn.exec_driver_sql(SQL)
-
-print("\u2705  acled_monthly_enriched created")
+if __name__ == "__main__":
+    main()

--- a/scripts/pull_acled.py
+++ b/scripts/pull_acled.py
@@ -1,129 +1,19 @@
 #!/usr/bin/env python3
-"""
-Pathfinder – universal ACLED puller
------------------------------------
-Usage examples
-$ python scripts/pull_acled.py Sudan Chad
-$ python scripts/pull_acled.py northern_africa
-$ python scripts/pull_acled.py --list            # show valid names
-"""
+"""Pathfinder – universal ACLED puller."""
 
-from __future__ import annotations
-from pathlib import Path
-import os, sys, time, datetime as dt, requests, pandas as pd
-from sqlalchemy import create_engine
+from pathfinder.etl.pull_acled import main, list_countries
+import sys
 
-# ---------------------------------------------------------------------------
-# 0. CLI parsing
-# ---------------------------------------------------------------------------
-args = sys.argv[1:]
-if "--help" in args or "-h" in args:
-    print(__doc__)
-    sys.exit(0)
-LIST_MODE = "--list" in args
-args = [a for a in args if a != "--list"]
-
-# ---------------------------------------------------------------------------
-# 1. ENV – token & email
-# ---------------------------------------------------------------------------
-TOKEN = os.getenv("ACLED_TOKEN")
-EMAIL = os.getenv("ACLED_EMAIL")
-if not TOKEN or not EMAIL:
-    sys.exit(
-        "ACLED_TOKEN and ACLED_EMAIL environment variables must be set or provided"
-    )
-
-# ---------------------------------------------------------------------------
-# 2. Fetch / cache ISO table
-# ---------------------------------------------------------------------------
-CACHE = Path("data/meta/iso_cache.csv")
-CACHE.parent.mkdir(parents=True, exist_ok=True)
-if CACHE.exists() and CACHE.stat().st_mtime > time.time() - 86400:
-    iso_df = pd.read_csv(CACHE)
-else:
-    print("🔄  Downloading country list from ACLED …")
-    url_iso = f"https://api.acleddata.com/country/read?key={TOKEN}&email={EMAIL}&limit=0&format=json"
-    resp = requests.get(url_iso, timeout=30)
-    resp.raise_for_status()
-    iso_df = pd.DataFrame(resp.json()["data"])[["country", "iso", "iso3"]]
-    iso_df.to_csv(CACHE, index=False)
-
-country_lookup = (
-    iso_df.assign(iso=lambda d: d["iso"].astype(str))
-          .set_index("country", drop=True)["iso"]
-          .to_dict()
-)
-
-# region aliases (add more if desired)
-REGION_ALIASES: dict[str, int] = {
-    "western_africa": 1, "middle_africa": 2, "eastern_africa": 3,
-    "southern_africa": 4, "northern_africa": 5, "south_asia": 7,
-    "southeast_asia": 9, "middle_east": 11, "europe": 12,
-    "caucasus_central_asia": 13, "central_america": 14, "south_america": 15,
-    "caribbean": 16, "east_asia": 17, "north_america": 18,
-    "oceania": 19, "antarctica": 20,
-}
-
-if LIST_MODE:
-    print("\n".join(sorted(country_lookup.keys())))
-    sys.exit(0)
-
-if not args:
-    sys.exit("❌  No country or region arguments supplied.  Use --list to see options.")
-
-# ---------------------------------------------------------------------------
-# 3. Build query parts
-# ---------------------------------------------------------------------------
-iso_params, region_params, missing = [], [], []
-for item in args:
-    if item in country_lookup:
-        iso_params.append(f"&iso={country_lookup[item]}")
-    elif item in REGION_ALIASES:
-        region_params.append(f"&region={REGION_ALIASES[item]}")
-    else:
-        missing.append(item)
-
-if missing:
-    sys.exit(f"❌  Unrecognised names: {missing}\nRun with --list to see valid country names.")
-
-iso_query    = "".join(iso_params)
-region_query = "".join(region_params)
-
-# ---------------------------------------------------------------------------
-# 4. Time window & URL
-# ---------------------------------------------------------------------------
-DAYS_BACK = 14
-today      = dt.date.today()
-start_date = today - dt.timedelta(days=DAYS_BACK)
-
-url = (
-    "https://api.acleddata.com/acled/readme?"
-    f"email={EMAIL}&key={TOKEN}"
-    f"{iso_query}{region_query}"
-    f"&event_date={start_date}|{today}"
-    f"&limit=20000&format=json"
-)
-
-print("⬇️  Fetching ACLED:", url)
-resp = requests.get(url, timeout=60)
-resp.raise_for_status()
-js = resp.json()
-rows = js.get("data", [])
-if not rows:
-    sys.exit("⚠️  Query succeeded but returned zero rows – check region permissions or spelling.")
-
-df = pd.DataFrame(rows)
-
-# ---------------------------------------------------------------------------
-# 5. Save + load to PostGIS
-# ---------------------------------------------------------------------------
-raw_dir = Path("data/raw")
-raw_dir.mkdir(exist_ok=True, parents=True)
-out_csv = raw_dir / f"acled_{'_'.join(args)}_{today}.csv"
-df.to_csv(out_csv, index=False)
-print(f"💾  Saved {len(df):,} rows → {out_csv}")
-
-pg_url = "postgresql://postgres:postgres@db:5432/pathfinder"
-create_engine(pg_url).connect().close()  # quick connectivity test
-df.to_sql("events_raw", pg_url, if_exists="replace", index=False)
-print("✅  Written to PostGIS table events_raw")
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if "--list" in args:
+        from os import getenv
+        token = getenv("ACLED_TOKEN")
+        email = getenv("ACLED_EMAIL")
+        if token and email:
+            for name in list_countries(token, email):
+                print(name)
+        else:
+            print("ACLED_TOKEN and ACLED_EMAIL must be set")
+        sys.exit(0)
+    main(args)


### PR DESCRIPTION
## Summary
- refactor `pull_acled` and `enrich_admin2` into modules under `pathfinder.etl`
- add standardized logging helper
- update scripts to use new modules
- make `pathfinder` imports resilient to missing deps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - pandas/sqlalchemy not installed)*