### PR TITLE
Fix GitHub Pages artifact upload step

### DIFF
--- a/.github/workflows/deploy_dashboard.yml
+++ b/.github/workflows/deploy_dashboard.yml
@@ -25,8 +25,9 @@ jobs:
           mkdir site
           wget -O site/index.html http://localhost:8501
         timeout-minutes: 2
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-artifact@v3
         with:
+          name: site-artifact
           path: site
 
   deploy:
@@ -38,3 +39,5 @@ jobs:
     steps:
       - uses: actions/configure-pages@v3
       - uses: actions/deploy-pages@v1
+        with:
+          artifact_name: site-artifact


### PR DESCRIPTION
## Summary
- ensure correct artifact action usage in deploy workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683db105fa5c8329ba96677db9ad4200