### PR TITLE
Add PostGIS service for dashboard workflow

### DIFF
--- a/.github/workflows/deploy_dashboard.yml
+++ b/.github/workflows/deploy_dashboard.yml
@@ -8,6 +8,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      db:
+        image: postgis/postgis:16-3.4
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: pathfinder
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -18,7 +30,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_HOST: db
+          POSTGRES_HOST: localhost
           POSTGRES_DB: pathfinder
       - run: |
           sleep 15


### PR DESCRIPTION
## Summary
- start a PostGIS service for the dashboard deploy workflow
- connect the Streamlit step to the local PostGIS service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pathfinder')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas>=2.2)*

------
https://chatgpt.com/codex/tasks/task_e_683db3d642a483299cf7fe4be0541a52