### PR TITLE
Add packaging metadata and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,21 @@ Raw files live under **`data/raw/`** and the ETL scripts populate the PostGIS da
 # clone & start the stack
 git clone <repo-url>
 cd Pathfinder
+pip install -e .    # install the package for local tests
 cp .env.example .env   # fill in your ACLED credentials
 docker compose up      # brings up PostGIS and Jupyter
 
 # alternatively, use the helper script
 bash scripts/setup_dev_env.sh
+```
+
+### Running tests
+
+Install the package locally and run pytest:
+
+```bash
+pip install -e .
+pytest
 ```
 
 ### Data ingest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pathfinder"
+version = "0.1.0"
+description = "Risk-aware mapping tools for humanitarian operations"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+authors = [{name = "Unknown", email = ""}]
+
+[project.urls]
+Homepage = "https://example.com"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["pathfinder*"]


### PR DESCRIPTION
## Summary
- package the `pathfinder` module via `pyproject.toml`
- document installing the package and running tests

## Testing
- `pip install -e . --no-build-isolation` *(fails: BackendUnavailable - Cannot import 'setuptools.build_meta')*
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683db3dcbd2083298484ebe333355583