### PR TITLE
Add cache ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ data/raw/*.zip
 data/raw/*.gpkg
 data/raw/*.xlsx
 .env
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/


### PR DESCRIPTION
## Summary
- expand `.gitignore` to ignore compiled artifacts and distribution folders

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683db3dda70883298f1654bf5a8961d5