### PR TITLE
feat(bootstrap): flexible HDX loader + road-schema auto-init

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r requirements.txt
 
+      - name: Bootstrap roads schema
+        run: python scripts/bootstrap_roads.py
+
       - name: Fetch newest HDX workbook
         run: bash scripts/fetch_hdx_pv.sh
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ docker compose up      # brings up PostGIS and Jupyter
 
 # alternatively, use the helper script
 bash scripts/setup_dev_env.sh
+
+# first-run helpers
+python scripts/bootstrap_roads.py
+python scratch/load_pv_monthly.py
+streamlit run dashboard/app.py
 ```
 
 ### Running tests
@@ -61,7 +66,9 @@ pytest
 | `scripts/pull_acled.py` | Pull ACLED events for one or more countries/regions (14‑day window by default) | `python scripts/pull_acled.py Sudan Chad` |
 | `scripts/fetch_hdx_sa_monthly.py` | South-Africa monthly aggregates (events & fatalities) → CSV + PostGIS | `python scripts/fetch_hdx_sa_monthly.py "<HDX-xlsx-URL>"` |
 | `scripts/fetch_hdx_sudan_roads.py` | HOT‑OSM Sudan roads export (ZIP) → GPKG + PostGIS | `python scripts/fetch_hdx_sudan_roads.py "<roads-zip-URL>"` |
+| `scripts/bootstrap_roads.py` | Create base road tables if missing | `python scripts/bootstrap_roads.py` |
 | `scripts/fetch_hdx_pv.sh` | Download Sudan political‑violence data from HDX | `bash scripts/fetch_hdx_pv.sh` |
+| `scratch/load_pv_monthly.py` | Ingest monthly Sudan violence workbook | `python scratch/load_pv_monthly.py` |
 | `scripts/enrich_admin2.py` | Load admin boundaries and enrich monthly events | `python scripts/enrich_admin2.py` |
 | `scripts/plot_monthly_totals.py` | Plot events & fatalities from PostGIS into `output.png` | `python scripts/plot_monthly_totals.py` |
 | `sql/03_geo_join.sql` | Materialised view of events within 5 km of primary roads | `psql -f sql/03_geo_join.sql` |

--- a/pathfinder/settings.py
+++ b/pathfinder/settings.py
@@ -1,0 +1,17 @@
+from functools import lru_cache
+from pathlib import Path
+import os
+import sqlalchemy as sa
+
+
+@lru_cache
+def engine() -> sa.Engine:
+    """Return a SQLAlchemy engine from ``$DATABASE_URL`` or docker defaults."""
+    url = os.getenv(
+        "DATABASE_URL",
+        "postgresql://postgres:postgres@db:5432/pathfinder",
+    )
+    return sa.create_engine(url, pool_pre_ping=True)
+
+
+DATA_RAW = Path(__file__).resolve().parents[1] / "data" / "raw"

--- a/scratch/map_roads.py
+++ b/scratch/map_roads.py
@@ -1,13 +1,19 @@
 # scratch/map_roads.py
-import geopandas as gpd, folium
-from sqlalchemy import create_engine
+import geopandas as gpd
+import folium
+from pathfinder.settings import engine
 
-engine = create_engine("postgresql://postgres:postgres@db:5432/pathfinder")
+HIWAYS = ["primary"]
 
 def main():
+    sql = (
+        "SELECT geom, highway FROM sudan_roads_osm "
+        "WHERE highway = ANY(%(hiways)s::text[]) LIMIT 1000"
+    )
     roads = gpd.read_postgis(
-        "SELECT geom, highway FROM sudan_roads_osm WHERE highway = 'primary' LIMIT 1000",
-        con=engine,
+        sql,
+        con=engine(),
+        params={"hiways": HIWAYS},
         geom_col="geom",
         crs=4326,
     )

--- a/scripts/bootstrap_roads.py
+++ b/scripts/bootstrap_roads.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Initialise road tables if missing."""
+
+from pathlib import Path
+import logging
+import sqlalchemy as sa
+from pathfinder.settings import engine
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    eng = engine()
+    insp = sa.inspect(eng)
+    if insp.has_table("roads_primary"):
+        logger.info("roads_primary table already exists")
+        return
+    try:
+        sql = Path("sql/01_normalize_road_layers.sql").read_text()
+        with eng.begin() as conn:
+            conn.exec_driver_sql(sql)
+        logger.info("Bootstrapped road schema")
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to bootstrap road schema: %s", exc)
+        raise
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- centralise DB connection and raw-data path in `settings.py`
- extend `load_pv_monthly.py` with flexible file discovery and format detection
- parameterise road SQL and use shared engine in `map_roads.py`
- add `scripts/bootstrap_roads.py` to initialise road schema
- update CI workflow to run bootstrap script
- document new steps in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683dced265648329861ef0f822c542ba