### PR TITLE
Fix SQLAlchemy parameter binding in bootstrap script

### DIFF
--- a/scripts/bootstrap_roads.py
+++ b/scripts/bootstrap_roads.py
@@ -4,10 +4,19 @@
 from pathlib import Path
 import logging
 import sqlalchemy as sa
+from sqlalchemy import text
 from pathfinder.settings import engine
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
+
+
+def execute_sql_file(engine: sa.Engine, sql_file_path: Path) -> None:
+    """Execute a SQL file using SQLAlchemy's text() wrapper."""
+
+    sql = sql_file_path.read_text()
+    with engine.begin() as conn:
+        conn.execute(text(sql))
 
 
 def main() -> None:
@@ -17,9 +26,7 @@ def main() -> None:
         logger.info("roads_primary table already exists")
         return
     try:
-        sql = Path("sql/01_normalize_road_layers.sql").read_text()
-        with eng.begin() as conn:
-            conn.exec_driver_sql(sql)
+        execute_sql_file(eng, Path("sql/01_normalize_road_layers.sql"))
         logger.info("Bootstrapped road schema")
     except Exception as exc:  # noqa: BLE001
         logger.error("Failed to bootstrap road schema: %s", exc)


### PR DESCRIPTION
## Summary
- add `execute_sql_file` helper using `text()` to avoid parameter binding
- run roads bootstrap using the helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6840c251419083299354626b8fbd31be