### PR TITLE
Replace monthly aggregates with Sudan HDX source

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Animated visualization showing geolocated ACLED events color-coded by event type
 └── docker-compose.yml  # local PostGIS + Jupyter stack
 ```
 
-Raw files live under **`data/raw/`** and the ETL scripts populate the PostGIS database running in the `db` container. The main tables are `events_raw`, `sa_monthly_violence` and `sudan_roads_osm`.
+Raw files live under **`data/raw/`** and the ETL scripts populate the PostGIS database running in the `db` container. The main tables are `events_raw`, `sudan_monthly_violence` and `sudan_roads_osm`.
 
 ## Quick start
 
@@ -102,7 +102,7 @@ pytest
 | script | purpose | example call |
 |--------|---------|--------------|
 | `scripts/pull_acled.py` | Pull ACLED events for one or more countries/regions (14‑day window by default) | `python scripts/pull_acled.py Sudan Chad` |
-| `scripts/fetch_hdx_sa_monthly.py` | South-Africa monthly aggregates (events & fatalities) → CSV + PostGIS | `python scripts/fetch_hdx_sa_monthly.py "<HDX-xlsx-URL>"` |
+| `scripts/fetch_hdx_sudan_admin2.py` | Sudan Admin2 monthly aggregates (events & fatalities) via HDX API | `python scripts/fetch_hdx_sudan_admin2.py` |
 | `scripts/fetch_hdx_sudan_roads.py` | HOT‑OSM Sudan roads export (ZIP) → GPKG + PostGIS | `python scripts/fetch_hdx_sudan_roads.py "<roads-zip-URL>"` |
 | `scripts/bootstrap_roads.py` | Create base road tables if missing | `python scripts/bootstrap_roads.py` |
 | `scripts/fetch_hdx_pv.sh` | Download Sudan political‑violence data from HDX | `bash scripts/fetch_hdx_pv.sh` |

--- a/pathfinder/etl/sudan_admin2_monthly.py
+++ b/pathfinder/etl/sudan_admin2_monthly.py
@@ -1,0 +1,187 @@
+"""Utilities for loading Sudan monthly political-violence aggregates."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import Engine, text
+
+from pathfinder.db import get_engine
+
+LOGGER = logging.getLogger(__name__)
+
+
+REQUIRED_COLUMNS = {
+    "country",
+    "admin1",
+    "admin2",
+    "iso3",
+    "admin2_pcode",
+    "admin1_pcode",
+    "month",
+    "year",
+    "events",
+    "fatalities",
+}
+
+
+def _normalise_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Return dataframe with snake_case columns."""
+    renamed = df.copy()
+    renamed.columns = [c.strip().lower().replace(" ", "_") for c in renamed.columns]
+    return renamed
+
+
+def transform_admin2_monthly(raw: pd.DataFrame) -> pd.DataFrame:
+    """Clean the raw HDX CSV and return Admin2-level monthly metrics.
+
+    Parameters
+    ----------
+    raw:
+        Raw dataframe as provided by HDX (Admin2 rows).
+
+    Returns
+    -------
+    pd.DataFrame
+        Columns: country, iso3, admin1, admin1_pcode, admin2, admin2_pcode,
+        year, month (numeric), events, fatalities.
+    """
+
+    df = _normalise_columns(raw)
+
+    missing = REQUIRED_COLUMNS - set(df.columns)
+    if missing:
+        msg = f"CSV is missing required columns: {sorted(missing)}"
+        LOGGER.error(msg)
+        raise ValueError(msg)
+
+    tidy = df.loc[:, [
+        "country",
+        "iso3",
+        "admin1",
+        "admin1_pcode",
+        "admin2",
+        "admin2_pcode",
+        "month",
+        "year",
+        "events",
+        "fatalities",
+    ]].copy()
+
+    tidy["month"] = tidy["month"].astype(str).str.strip()
+    tidy["year"] = tidy["year"].astype(int)
+
+    # Combine month name with year, convert to a numeric month (1-12)
+    month_dt = pd.to_datetime(
+        tidy["month"].str[:3] + " " + tidy["year"].astype(str),
+        format="%b %Y",
+        errors="coerce",
+    )
+    if month_dt.isna().any():
+        bad_rows = tidy.loc[month_dt.isna(), ["month", "year"]]
+        msg = f"Unparseable month/year combinations: {bad_rows.to_dict(orient='records')}"
+        LOGGER.error(msg)
+        raise ValueError(msg)
+    tidy["month"] = month_dt.dt.month.astype(int)
+
+    tidy["iso3"] = tidy["iso3"].astype(str).str.upper().str.strip()
+    tidy["country"] = tidy["country"].astype(str).str.strip()
+    tidy["admin1"] = tidy["admin1"].astype(str).str.strip()
+    tidy["admin2"] = tidy["admin2"].astype(str).str.strip()
+    tidy["admin1_pcode"] = tidy["admin1_pcode"].astype(str).str.strip()
+    tidy["admin2_pcode"] = tidy["admin2_pcode"].astype(str).str.strip()
+
+    tidy["events"] = tidy["events"].fillna(0).astype(int)
+    tidy["fatalities"] = tidy["fatalities"].fillna(0).astype(int)
+
+    tidy = tidy.sort_values(["iso3", "admin1_pcode", "admin2_pcode", "year", "month"]).reset_index(drop=True)
+    return tidy
+
+
+def aggregate_country_monthly(admin2_df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate Admin2 metrics into monthly country totals."""
+    grouped = (
+        admin2_df.groupby(["iso3", "year", "month"], as_index=False)[["events", "fatalities"]]
+        .sum()
+        .rename(columns={"iso3": "iso"})
+        .sort_values(["iso", "year", "month"])
+        .reset_index(drop=True)
+    )
+    return grouped
+
+
+def load_admin2_monthly_csv(csv_path: Path, engine: Engine | None = None) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Load the Sudan Admin2 monthly CSV into PostGIS.
+
+    Parameters
+    ----------
+    csv_path:
+        Local path to the HDX CSV snapshot.
+    engine:
+        Optional SQLAlchemy engine. If omitted, :func:`pathfinder.db.get_engine`
+        is used.
+
+    Returns
+    -------
+    Tuple[pd.DataFrame, pd.DataFrame]
+        (admin2_df, monthly_df) dataframes used for persistence.
+    """
+
+    if engine is None:
+        engine = get_engine()
+
+    csv_path = Path(csv_path)
+    if not csv_path.exists():
+        msg = f"CSV path does not exist: {csv_path}"
+        LOGGER.error(msg)
+        raise FileNotFoundError(msg)
+
+    LOGGER.info("reading csv", extra={"path": str(csv_path)})
+    raw = pd.read_csv(csv_path)
+
+    admin2_df = transform_admin2_monthly(raw)
+    monthly_df = aggregate_country_monthly(admin2_df)
+
+    LOGGER.info(
+        "writing to postgis",
+        extra={
+            "admin2_rows": len(admin2_df),
+            "monthly_rows": len(monthly_df),
+        },
+    )
+
+    with engine.begin() as conn:
+        admin2_df.to_sql("sudan_admin2_monthly", conn, if_exists="replace", index=False)
+        monthly_df.to_sql("sudan_monthly_violence", conn, if_exists="replace", index=False)
+
+        conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_sudan_admin2_monthly_pcode_month "
+                "ON sudan_admin2_monthly(admin2_pcode, year, month)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_sudan_monthly_violence_iso_month "
+                "ON sudan_monthly_violence(iso, year, month)"
+            )
+        )
+
+    return admin2_df, monthly_df
+
+
+METADATA_PATH = Path("data/raw/sudan_admin2_monthly.meta.json")
+
+
+def write_metadata(metadata: dict) -> None:
+    METADATA_PATH.parent.mkdir(parents=True, exist_ok=True)
+    METADATA_PATH.write_text(json.dumps(metadata, indent=2, sort_keys=True))
+
+
+def read_metadata() -> dict:
+    if not METADATA_PATH.exists():
+        return {}
+    return json.loads(METADATA_PATH.read_text())

--- a/pathfinder/queries.py
+++ b/pathfinder/queries.py
@@ -13,7 +13,7 @@ def monthly_events(iso, engine=None):
         engine = get_engine()
     sql = (
         "SELECT year, month, events, fatalities "
-        "FROM sa_monthly_violence "
+        "FROM sudan_monthly_violence "
         "WHERE iso = %(iso)s "
         "ORDER BY year, month"
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,8 @@ matplotlib
 
 # ── misc ───────────────────────────────────────────────
 python-dotenv
+# HTTP + APIs
+requests>=2.31
 # --- dashboard ---
 streamlit
 altair

--- a/scripts/fetch_hdx_sudan_admin2.py
+++ b/scripts/fetch_hdx_sudan_admin2.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Fetch the latest Sudan Admin2 monthly CSV from HDX and load into PostGIS."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Optional
+
+import requests
+from requests import RequestException
+
+from pathfinder.etl.sudan_admin2_monthly import (
+    load_admin2_monthly_csv,
+    read_metadata,
+    write_metadata,
+)
+
+LOGGER = logging.getLogger("pathfinder.scripts.fetch_hdx_sudan_admin2")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+
+HDX_API = "https://data.humdata.org/api/3/action/package_show"
+DEFAULT_DATASET = "sudan-acled-conflict-data"
+DEFAULT_DEST = Path("data/raw/sudan_admin2_monthly.csv")
+RESOURCE_SUBSTRING = "Sudan_PV - Data.csv"
+TIMEOUT = 60
+
+
+def fetch_latest_csv(dataset: str, dest: Path) -> Optional[Path]:
+    """Return the path to the downloaded CSV, or ``None`` if already current."""
+    params = {"id": dataset}
+    LOGGER.info("fetching package metadata", extra={"dataset": dataset})
+    try:
+        response = requests.get(HDX_API, params=params, timeout=TIMEOUT)
+        response.raise_for_status()
+    except RequestException as exc:
+        if Path(dest).exists():
+            LOGGER.warning(
+                "hdx request failed; using cached file",
+                extra={"path": str(dest), "error": str(exc)},
+            )
+            return dest
+        raise
+
+    package = response.json()["result"]
+
+    resource = next(
+        (
+            r
+            for r in package["resources"]
+            if r.get("url", "").lower().endswith(".csv")
+            and RESOURCE_SUBSTRING.lower() in r.get("name", "").lower()
+        ),
+        None,
+    )
+    if resource is None:
+        resource = next(
+            (r for r in package["resources"] if r.get("format", "").lower() == "csv"),
+            None,
+        )
+    if resource is None:
+        raise RuntimeError("Could not locate Sudan Admin2 CSV resource in HDX package")
+
+    metadata = read_metadata()
+    last_modified = resource.get("last_modified") or resource.get("revision_timestamp")
+    if metadata.get("last_modified") == last_modified and Path(dest).exists():
+        LOGGER.info("local copy already current", extra={"path": str(dest)})
+        return None
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    url = resource["url"]
+    LOGGER.info("downloading", extra={"url": url, "dest": str(dest)})
+
+    with requests.get(url, stream=True, timeout=TIMEOUT) as resp:
+        resp.raise_for_status()
+        with open(dest, "wb") as fh:
+            for chunk in resp.iter_content(chunk_size=8192):
+                if not chunk:
+                    continue
+                fh.write(chunk)
+
+    write_metadata({
+        "dataset": dataset,
+        "resource_id": resource.get("id"),
+        "last_modified": last_modified,
+        "download_url": url,
+    })
+    LOGGER.info("downloaded", extra={"bytes": dest.stat().st_size})
+    return dest
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", default=DEFAULT_DATASET, help="HDX dataset slug (default: %(default)s)")
+    parser.add_argument("--dest", default=str(DEFAULT_DEST), help="Where to save the CSV (default: %(default)s)")
+    parser.add_argument(
+        "--skip-load",
+        action="store_true",
+        help="Only download the CSV; do not load into PostGIS",
+    )
+    args = parser.parse_args()
+
+    dest_path = fetch_latest_csv(args.dataset, Path(args.dest))
+    if dest_path is None:
+        dest_path = Path(args.dest)
+
+    if args.skip_load:
+        LOGGER.info("skipping database load by request")
+        return
+
+    load_admin2_monthly_csv(dest_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sudan_admin2_monthly.py
+++ b/tests/test_sudan_admin2_monthly.py
@@ -1,0 +1,55 @@
+import pandas as pd
+
+from pathfinder.etl.sudan_admin2_monthly import (
+    aggregate_country_monthly,
+    transform_admin2_monthly,
+)
+
+
+def sample_raw_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Country": ["Sudan", "Sudan"],
+            "Admin1": ["Blue Nile", "Blue Nile"],
+            "Admin2": ["Geisan", "Geisan"],
+            "ISO3": ["sdn", "SDN"],
+            "Admin2 Pcode": [" SD08109 ", "SD08109"],
+            "Admin1 Pcode": ["SD08", "SD08"],
+            "Month": ["January", "February"],
+            "Year": [2024, 2024],
+            "Events": [3, 4],
+            "Fatalities": [1, 2],
+        }
+    )
+
+
+def test_transform_admin2_monthly_parses_months():
+    raw = sample_raw_df()
+    tidy = transform_admin2_monthly(raw)
+
+    assert tidy.loc[0, "month"] == 1
+    assert tidy.loc[1, "month"] == 2
+    assert tidy.loc[0, "iso3"] == "SDN"
+    assert tidy.loc[0, "admin2_pcode"] == "SD08109"
+    assert list(tidy.columns) == [
+        "country",
+        "iso3",
+        "admin1",
+        "admin1_pcode",
+        "admin2",
+        "admin2_pcode",
+        "month",
+        "year",
+        "events",
+        "fatalities",
+    ]
+
+
+def test_aggregate_country_monthly_sums_events():
+    tidy = transform_admin2_monthly(sample_raw_df())
+    aggregated = aggregate_country_monthly(tidy)
+
+    assert list(aggregated.columns) == ["iso", "year", "month", "events", "fatalities"]
+    january = aggregated.loc[(aggregated["year"] == 2024) & (aggregated["month"] == 1)]
+    assert int(january["events"].iloc[0]) == 3
+    assert int(january["fatalities"].iloc[0]) == 1


### PR DESCRIPTION
## Summary
- add a reusable ETL helper that cleans the Sudan Admin2 monthly CSV and loads aggregated totals into PostGIS
- add a HDX API-powered fetch script so the latest CSV can be pulled and cached for the dashboard
- update queries, documentation, requirements, and tests to use the Sudan monthly aggregates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e15bb25ea88329bfb1517dd3323d1d